### PR TITLE
Fixes code block without annotated language

### DIFF
--- a/src/guides/tracked-properties.md
+++ b/src/guides/tracked-properties.md
@@ -68,7 +68,7 @@ export default class extends Component {
 
 Unlike our first version, this component will throw an exception when we set the `person` property:
 
-```
+```markdown
 Uncaught Error: The 'person' property on the person-viewer component was changed after it had been rendered. Properties that change after being rendered must be tracked. Use the @tracked decorator to mark this as a tracked property.
 ```
 

--- a/src/styles/_prism-overrides.scss
+++ b/src/styles/_prism-overrides.scss
@@ -6,3 +6,7 @@ pre[class*="language-"] {
 .token.block {
   display: initial;
 }
+
+code {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
Looks like prism only adds code styling on code blocks with language specified. This causes non-annotated blocks to have default styling of code + pre, which is non-word-breaking block element.

This causes some glitches:

<img width="1205" alt="screen shot 2017-03-29 at 11 01 06" src="https://cloud.githubusercontent.com/assets/606374/24446841/397accc2-146f-11e7-8b65-8f88ad965b05.png">

An obvious quick fix for this is to just annotate the block with a language as in this PR. Another fix could be to add styling for `code pre` without any class. But this has higher chance of collisions of specificity etc.

With markdown as language (as it's just text. Could be anything really) it now looks like this:

<img width="900" alt="screen shot 2017-03-29 at 11 01 14" src="https://cloud.githubusercontent.com/assets/606374/24446902/8125fff6-146f-11e7-8249-f4cd6e8d61aa.png">

Let me know if I should fix this with a specific style on `code pre` that simulates same style as prism code blocks. Another possible fix could be to quote the error instead.