### PR TITLE
Fix filesystem-layout

### DIFF
--- a/src/guides/filesystem-layout.md
+++ b/src/guides/filesystem-layout.md
@@ -3,7 +3,7 @@
 Now that we're up and running, let's take a look at how things are setup. Here's what our brand-new `my-app` currently looks like:
 
 ```sh
-app
+my-app
 ├── config 
 │   └── environment.js
 ├── dist/
@@ -28,42 +28,42 @@ app
 
 Briefly, those files and folders are:
 
-- `app/config/environment.js`: the base Glimmer config file
-- `app/dist`: your built files end up here
-- `app/src/config/*`: configuration files to keep Typescript happy. *Note: Glimmer only runs in Typescript at the moment. We aim to quickly add ES2015 Javascript support as well.*
-- `app/src/index.ts`: used to do initial app config before our Glimmer app boots (the div ID Glimmer renders into is set here (see the `containerElement` variable)
-- `app/ember-cli-build.js`: used to configure Ember-CLI in various ways (importing vendor files, Broccoli options, etc.)
+- `my-app/config/environment.js`: the base Glimmer config file
+- `my-app/dist`: your built files end up here
+- `my-app/src/config/*`: configuration files to keep Typescript happy. *Note: Glimmer only runs in Typescript at the moment. We aim to quickly add ES2015 Javascript support as well.*
+- `my-app/src/index.ts`: used to do initial app config before our Glimmer app boots (the div ID Glimmer renders into is set here (see the `containerElement` variable)
+- `my-app/ember-cli-build.js`: used to configure Ember-CLI in various ways (importing vendor files, Broccoli options, etc.)
 
-However, where we'll spend most of our time is in the `app/src/ui` folder.
+However, where we'll spend most of our time is in the `my-app/src/ui` folder.
 
 ## The UI folder
 
-As you can see, Glimmer puts all our components in the `app/src/ui/components` folder with the `my-app` component being where our app logic really begins. All other logic and components should be referenced in the `my-app/template.hbs` file (and we can nest them as deeply as we desire).
+As you can see, Glimmer puts all our components in the `my-app/src/ui/components` folder with the `my-app` component being where our app logic really begins. All other logic and components should be referenced in the `my-app/template.hbs` file (and we can nest them as deeply as we desire).
 
 So let's add a new component in Glimmer. To do so, we'll run the following command to generate an initial blueprint for a component:
 
 ```sh
-$ ember g glimmer-component hello-portland
+$ ember g glimmer-component hello-glimmer
 installing component
-  create app/src/ui/components/hello-portland/component.ts
-  create app/src/ui/components/hello-portland/template.hbs
+  create src/ui/components/hello-glimmer/component.ts
+  create src/ui/components/hello-glimmer/template.hbs
 ```
 
-As you can see, we generate two files (`component.ts` and `template.hbs`) in the newly created `src/ui/components/hello-portland` folder. A Glimmer component uses a template to generate all our HTML (using a [Handlebars](http://handlebarsjs.com) template with Glimmer/Ember additions) and a Typescript/Javascript file that provides additional properties and event handlers (known as actions) to our template. We'll cover more details about how Handlebars works on subsequent pages.
+As you can see, we generate two files (`component.ts` and `template.hbs`) in the newly created `src/ui/components/hello-glimmer` folder. A Glimmer component uses a template to generate all our HTML (using a [Handlebars](http://handlebarsjs.com) template with Glimmer/Ember additions) and a Typescript/Javascript file that provides additional properties and event handlers (known as actions) to our template. We'll cover more details about how Handlebars works on subsequent pages.
 
 All other components will also live in `src/ui/components` unless we deliberately nest them. So for example, if we add a second component called `conference-speakers`:
 
 ```sh
 $ ember g glimmer-component conference-speakers
 installing component
-  create app/src/ui/components/conference-speakers/component.ts
-  create app/src/ui/components/conference-speakers/template.hbs
+  create src/ui/components/conference-speakers/component.ts
+  create src/ui/components/conference-speakers/template.hbs
 ```
 
 we will see our new `conference-speakers` component added to our UI folder:
 
 ```sh
-app
+my-app
 │
 ... snipped ...
 
@@ -73,10 +73,7 @@ app
         │   ├── conference-speakers
         │   │   ├── component.ts
         │   │   └── template.hbs
-        │   ├── hello-glimmer
-        │   │   ├── component.ts
-        │   │   └── template.hbs
-        │   └── hello-portland
+        │   └── hello-glimmer
         │       ├── component.ts
         │       └── template.hbs
         ├── styles
@@ -95,14 +92,14 @@ But we can also add sub-components to our app to nest those components more deep
 ```sh
 $ ember g glimmer-component conference-speakers/conference-speaker
 installing component
-  create app/src/ui/components/conference-speakers/conference-speaker/component.ts
-  create app/src/ui/components/conference-speakers/conference-speaker/template.hbs
+  create src/ui/components/conference-speakers/conference-speaker/component.ts
+  create src/ui/components/conference-speakers/conference-speaker/template.hbs
 ```
 
 This generates our component inside our `conference-speakers` folder:
 
 ```sh
-app
+my-app
 │
 ... snipped ...
 
@@ -136,29 +133,3 @@ More details on the "local resolution" strategy will be posted shortly.
 ## Styles
 
 Depending on where you are using your Glimmer app, your containing apps styles will already be affecting the look of your app. However, you can also add new styles that only apply to your Glimmer components by editing `src/ui/styles/app.css`
-
-```sh
-app
-│
-... snipped ...
-
-└── src
-    └── ui
-│   ├── module-map.ts
-│   └── resolver-configuration.ts
-├── ui
-│   ├── components
-
-... snipped ...
-
-│   │   └── my-app
-│   │       ├── component.ts
-│   │       └── template.hbs
-│   ├── styles
-│   │   └── app.css
-│   └── index.html
-├── utils
-│   └── md5.ts
-├── index.ts
-└── main.ts
-```


### PR DESCRIPTION
This commit does:

* Remove `hello-portland` for `hello-glimmer` (there was already a reference to `hello-glimmer` though it was not generated in the tutorial.
* Change the `app` root to `my-app` and some related changes.
* Fix command outputs.