### PR TITLE
[DOC] make homepage reference NPM to be consistent with emberjs.com

### DIFF
--- a/src/partials/_introduction.ejs
+++ b/src/partials/_introduction.ejs
@@ -6,7 +6,7 @@
       <ol>
         <li>
           <small>Install the Ember build tool:</small><br>
-          <code>yarn global add ember-cli/ember-cli</code>
+          <code>npm install -g ember-cli</code>
         </li>
 
         <li>


### PR DESCRIPTION
Wanting to normalize more between Emberjs.com doc and Glimmerjs.com doc. @rwjblue recommended moving this one to conform rather than the other way around. 