### PR TITLE
Define link colors for guides

### DIFF
--- a/src/_layout.ejs
+++ b/src/_layout.ejs
@@ -13,7 +13,7 @@
       <link rel="shortcut icon" href="/images/favicon.png">
     </head>
 
-    <body class="<%= current.source %>">
+    <body class="<%= current.path.join(' ') %>">
       <div class="max-width-4 mx-auto p2">
         <%- partial("partials/_header") %>
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -7,6 +7,7 @@
 @import "components/_raised-panel";
 
 @import "pages/_index";
+@import "pages/_guides";
 
 @import "partials/_footer";
 @import "partials/_hero";

--- a/src/styles/pages/_guides.scss
+++ b/src/styles/pages/_guides.scss
@@ -1,0 +1,15 @@
+.guides {
+  .logo > a {
+    &, &:hover, &:focus {
+      color: #000;
+    }
+  }
+
+  a {
+    color: $tint-color;
+
+    &:hover, &:focus {
+      color: darken($tint-color, 10%);
+    }
+  }
+}


### PR DESCRIPTION
The default user agent style gives the guides a quite "unfinished" feel.

Screenshot:
![cceef60c-282a-456c-b4f3-753b9f0329fe](https://cloud.githubusercontent.com/assets/213788/24829497/2efcb4a2-1c73-11e7-8911-92e910a631fc.png)
