### PR TITLE
Change text color of code blocks in introduction from white to black

### DIFF
--- a/src/styles/partials/_introduction.scss
+++ b/src/styles/partials/_introduction.scss
@@ -3,7 +3,7 @@
 }
 
 .introduction code {
-  color: white;
+  color: black;
 }
 
 .introduction ol {


### PR DESCRIPTION
The code blocks on the home page are currently unreadable 🤕 

*Before*

<img width="541" alt="before" src="https://cloud.githubusercontent.com/assets/6979137/24830818/2c06072a-1c5b-11e7-85f0-74d348ec8841.png">

*After*

<img width="471" alt="after" src="https://cloud.githubusercontent.com/assets/6979137/24830820/2ee0d2b8-1c5b-11e7-96fb-31bffc252626.png">
