### PR TITLE
[DOC] Fix how render component

### DIFF
--- a/src/guides/filesystem-layout.md
+++ b/src/guides/filesystem-layout.md
@@ -88,7 +88,7 @@ This then allows us to use that component as a top-level component in our `my-ap
   <conference-speakers />
 </div>
 ```
-Whenever we invoke a component, we need it to be inside the element (i.e `<div><my-component></div>`).
+Whenever we invoke a component, we need it to be inside of a html element (i.e `<div><my-component></div>`).
 
 But we can also add sub-components to our app to nest those components more deeply in our folder tree. Let's generate one more component:
 

--- a/src/guides/filesystem-layout.md
+++ b/src/guides/filesystem-layout.md
@@ -88,7 +88,7 @@ This then allows us to use that component as a top-level component in our `my-ap
   <conference-speakers />
 </div>
 ```
-Whenever we invoke a component, we need it to be inside of a html element (i.e `<div><my-component></div>`).
+All content in a template must be inside a unique html element (i.e `<div><my-component></ div>`).
 
 But we can also add sub-components to our app to nest those components more deeply in our folder tree. Let's generate one more component:
 

--- a/src/guides/filesystem-layout.md
+++ b/src/guides/filesystem-layout.md
@@ -84,8 +84,12 @@ my-app
 This then allows us to use that component as a top-level component in our `my-app/template.hbs` file:
 
 ```hbs
-<conference-speakers />
+<div>
+  <conference-speakers />
+</div>
 ```
+Whenever we invoke a component, we need it to be inside the element (i.e `<div><my-component></div>`).
+
 But we can also add sub-components to our app to nest those components more deeply in our folder tree. Let's generate one more component:
 
 ```sh
@@ -117,7 +121,9 @@ my-app
 Our new component then is only useable from inside our `conference-speakers/template.hbs` file:
 
 ```hbs
-<conference-speaker />
+<div>
+  <conference-speaker />
+</div>
 ```
 
 Glimmer uses a "local resolution" with nested components where the following syntax will not work in our main component (`my-app/template.hbs`):

--- a/src/guides/filesystem-layout.md
+++ b/src/guides/filesystem-layout.md
@@ -81,6 +81,7 @@ my-app
 
 ... snipped ...
 ```
+
 This then allows us to use that component as a top-level component in our `my-app/template.hbs` file:
 
 ```hbs
@@ -88,7 +89,6 @@ This then allows us to use that component as a top-level component in our `my-ap
   <conference-speakers />
 </div>
 ```
-All content in a template must be inside a unique html element (i.e `<div><my-component></ div>`).
 
 But we can also add sub-components to our app to nest those components more deeply in our folder tree. Let's generate one more component:
 


### PR DESCRIPTION
In glimmer when do render of a component in a template we need wrapper this component with `div` element. Follow the [demo](https://github.com/glimmerjs/glimmer-demos/blob/master/src/ui/components/glimmer-demos/template.hbs) as palpability.