### PR TITLE
Group guides by sections

### DIFF
--- a/src/guides/_data.json
+++ b/src/guides/_data.json
@@ -3,24 +3,31 @@
     "layout": false
   },
   "installing": {
-    "title": "Installing"
+    "title": "Installing",
+    "section": "Quickstart"
   },
   "getting-started": {
-    "title": "Getting Started"
+    "title": "Getting Started",
+    "section": "Quickstart"
   },
   "filesystem-layout": {
-    "title": "Filesystem Layout"
+    "title": "Filesystem Layout",
+    "section": "Quickstart"
   },
   "templates-and-helpers": {
-    "title": "Templates and Helpers"
+    "title": "Templates and Helpers",
+    "section": "Quickstart"
   },
   "components-and-actions": {
-    "title": "Components and Actions"
+    "title": "Components and Actions",
+    "section": "Quickstart"
   },
   "using-glimmer-as-web-components": {
-    "title": "Using Glimmer as Web Components"
+    "title": "Using Glimmer as Web Components",
+    "section": "Recipes"
   },
   "tracked-properties": {
-    "title": "Change Tracking with Tracked Properties"
+    "title": "Change Tracking with Tracked Properties",
+    "section": "In Depth"
   }
 }

--- a/src/partials/_sidebar.ejs
+++ b/src/partials/_sidebar.ejs
@@ -1,5 +1,18 @@
 <ul class="sidebar">
-  <% for (let slug in public.guides._data) { %>
-    <li><a href="/guides/<%= slug %>"><%= public.guides._data[slug].title %></a></li>
+  <% let data = public.guides._data %>
+  <% let sections = [] %>
+
+  <% for (let slug in data) { %>
+    <% if (sections.indexOf(data[slug].section) === -1) sections.push(data[slug].section) %>
+  <% }; %>
+
+  <% for (let index in sections) { %>
+    <h3><%= sections[index] %></h3>
+
+    <% for (let slug in data) { %>
+      <% if (data[slug].section === sections[index]) {%>
+        <li><a href="/guides/<%= slug %>"><%= public.guides._data[slug].title %></a></li>
+      <% }; %>
+    <% }; %>
   <% }; %>
 </ul>

--- a/src/styles/partials/_sidebar.scss
+++ b/src/styles/partials/_sidebar.scss
@@ -2,6 +2,7 @@
 	list-style-position: inside;
 	list-style: none;
 	padding: 0;
+	margin-top: 2em;
 }
 
 .sidebar li {


### PR DESCRIPTION
![screen shot 2017-05-06 at 10 44 48 pm](https://cloud.githubusercontent.com/assets/9383/25777548/5c2c6a0c-32ae-11e7-9f2d-0d4fc3716887.png)

Assuming maintaining the current set of urls is a priority, I've added a guides "section" to the harp meta data file and group them in the sidebar partial (originally proposed in #73). I'd hope there is a better way to do it than I have, but from what I can tell of harp, this is the best way to go about it. 

I've added the recipes section as well [based on a comment](https://embercommunity.slack.com/archives/C04KG57CF/p1494022957327429?thread_ts=1493941448.062179&cid=C04KG57CF) from @locks. 

Another option for this is to do the grouping by simply using folders. This would be nice but would require harp's less-than-optimal client-side redirects if we didn't want to 404 anyone. 