### PR TITLE
fix(docs): remove ember-cli version

### DIFF
--- a/src/partials/_introduction.ejs
+++ b/src/partials/_introduction.ejs
@@ -6,7 +6,7 @@
       <ol>
         <li>
           <small>Install the Ember build tool:</small><br>
-          <code>npm install -g ember-cli@2.14.0-beta.2</code>
+          <code>npm install -g ember-cli</code>
         </li>
 
         <li>


### PR DESCRIPTION
Since 2.14 has been published