### PR TITLE
fix(styles): make code blocks seem more standalone

### DIFF
--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -22,7 +22,7 @@ code {
 }
 
 code:not([class]) {
-  padding: 0.25rem 0.15rem;
+  padding: 0.25rem 0.5rem;
   font-size: 0.8rem;
   background: #f5f2f0;
   border-radius: 3px;


### PR DESCRIPTION
Currently, it looks like additional content is hidden and you have to scroll horizontally to select all the code. This prevents that from seeming to be the case and makes the code appear to be complete and none of it hidden.