### PR TITLE
styles: tweak code selection

### DIFF
--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -22,9 +22,11 @@ code {
 }
 
 code:not([class]) {
-  padding: 0.25rem 0.5rem;
+  padding: 0.25em 0.45rem;
   font-size: 0.8rem;
   background: #f5f2f0;
+  line-height: 1.5;
   border-radius: 3px;
-  vertical-align: middle;
+  vertical-align: top;
+  display: inline-block;
 }


### PR DESCRIPTION
Before:

<img width="458" alt="screen shot 2017-07-05 at 6 49 35 pm" src="https://user-images.githubusercontent.com/34726/27914988-d87592ce-6232-11e7-9220-99b15d020ae4.png">

After:

<img width="458" alt="screen shot 2017-07-05 at 6 49 35 pm" src="https://user-images.githubusercontent.com/34726/27915001-e71f185e-6232-11e7-831d-e255ed012099.png">


The main change is when you select the text for copy & paste, the highlight now stays within the containing box. This is not visible in the screenshots.