### PR TITLE
Updating the docs around `node.js` version

### DIFF
--- a/src/guides/installing.md
+++ b/src/guides/installing.md
@@ -20,7 +20,7 @@ Ember CLI is built with JavaScript, and expects the [Node.js](https://nodejs.org
 runtime. It also requires dependencies fetched via [npm](https://www.npmjs.com/). npm is packaged with Node.js, so if your computer has Node.js
 installed you are ready to go.
 
-Ember requires Node.js 4 or higher and npm 2.14.2 or higher.
+Ember requires Node.js 6 or higher and npm 2.14.2 or higher.
 If you're not sure whether you have Node.js or the right version, run this on your
 command line:
 


### PR DESCRIPTION
Currently, we support only `node@6+` (mostly b/c of the way we wrote the blueprint). For example,

```typescript
// ember-cli-build.js
const { GlimmerApp } = require('@glimmer/application-pipeline');
```

Destructuring is not supported in 4.

related to https://github.com/glimmerjs/glimmer-vm/issues/579