### PR TITLE
Consistently use async / await syntax

### DIFF
--- a/src/guides/tracked-properties.md
+++ b/src/guides/tracked-properties.md
@@ -107,9 +107,9 @@ export default class extends Component {
   }
 
   loadPerson() {
-    fetch('https://api.example.com/person.json')
-      .then(request => request.json())
-      .then(({ person }) => this.person = person);
+    let request = await fetch('https://api.example.com/person.json');
+    let json = await request.json();
+    this.person = json.person;
   }
 }
 ```


### PR DESCRIPTION
In the tracked properties guide it looks like the first example had been updated to use
async await but the second one was still using `.then` syntax.

https://glimmerjs.com/guides/tracked-properties

### First example

![image](https://user-images.githubusercontent.com/831043/29485425-99732460-84c9-11e7-824c-8c8dbdc55a0a.png)

### Second example

![image](https://user-images.githubusercontent.com/831043/29485428-9f16a59a-84c9-11e7-960a-3352af2d8557.png)
