### PR TITLE
Fix ember-cli syntax for creating a web component

### DIFF
--- a/src/guides/using-glimmer-as-web-components.md
+++ b/src/guides/using-glimmer-as-web-components.md
@@ -7,8 +7,13 @@ In addition to using Glimmer for a widget on one section on a page, you can also
 Let's do another new app setup. Instead of doing an installation like we did originally, we'll now run the following command:
 
 ```sh
-ember new DisplayTile -b @glimmer/blueprint --web-component
+ember new DisplayTile -b @glimmer/blueprint --web-component=display-title
 ```
+
+> Note: there is currently a bug in ember-cli (@2.17.0) that reports
+> > The option '--web-component' is not registered with the new command. Run `ember new --help` for a list of supported options.
+>
+> This is just a messaging error. Your component project will still be created.
 
 When we add the `--web-component` flag, we reconfigure our app to expose our `display-tile` component as a Web Component to browsers. That in turn allows us to render markup like the following from a backend:
 


### PR DESCRIPTION
I used the guides to create a new web component project and got the following warning then subsequent error:

> The option '--web-component' is not registered with the new command. Run `ember new --help` for a list of supported options.

> Error creating new application. Removing generated directory `./user-stories-viewer`  
> You must provide a name for the web component, eg. `--web-component=button-list`

I have corrected the documentation to properly invoke a new web component project scaffold. In addition, I am warning people that they will *still* see a warning, even when using the correct command.

FYI, here is my entire terminal log for the session in which I discovered this:

```
Git Projects % ember new user-stories-viewer -b @glimmer/blueprint --web-component
The option '--web-component' is not registered with the new command. Run `ember new --help` for a list of supported options.
installing blueprint
  create .editorconfig
  create .ember-cli
  create .watchmanconfig
  create README.md
  create config/environment.js
  create config/module-map.d.ts
  create config/resolver-configuration.d.ts
  create config/targets.js
  create ember-cli-build.js
  create .gitignore
  create package.json
  create public/robots.txt
  create src/index.ts
  create src/main.ts
  create src/ui/components/UserStoriesViewer/component-test.ts
  create src/ui/components/UserStoriesViewer/component.ts
  create src/ui/components/UserStoriesViewer/template.hbs
  create src/ui/index.html
  create src/ui/styles/app.scss
  create src/utils/test-helpers/test-helper.ts
  create testem.json
  create tsconfig.json
  create tslint.json
  create yarn.lock
Error creating new application. Removing generated directory `./user-stories-viewer`
You must provide a name for the web component, eg. `--web-component=button-list`

Git Projects % ember new user-stories-viewer -b @glimmer/blueprint --web-component=user-stories-viewer
The option '--web-component' is not registered with the new command. Run `ember new --help` for a list of supported options.
installing blueprint
  create .editorconfig
  create .ember-cli
  create .watchmanconfig
  create README.md
  create config/environment.js
  create config/module-map.d.ts
  create config/resolver-configuration.d.ts
  create config/targets.js
  create ember-cli-build.js
  create .gitignore
  create package.json
  create public/robots.txt
  create src/index.ts
  create src/main.ts
  create src/ui/components/UserStoriesViewer/component-test.ts
  create src/ui/components/UserStoriesViewer/component.ts
  create src/ui/components/UserStoriesViewer/template.hbs
  create src/ui/index.html
  create src/ui/styles/app.scss
  create src/utils/test-helpers/test-helper.ts
  create testem.json
  create tsconfig.json
  create tslint.json
  create yarn.lock
  install package @glimmer/web-component
Yarn: Installed @glimmer/web-component
Yarn: Installed dependencies
Successfully initialized git.

Git Projects % ember -v
ember-cli: 2.17.0
node: 8.9.1
os: darwin x64

Git Projects % 
```