### PR TITLE
Add some clues about use in Ember

### DIFF
--- a/src/guides/installing.md
+++ b/src/guides/installing.md
@@ -1,3 +1,10 @@
+# Welcome to Glimmer!
+
+These guides will help you get started building your own Glimmer app and components!
+
+If you want to learn how to build Glimmer Components for an Ember.js app, please visit
+[the Ember Guides](https://guides.emberjs.com) instead.
+
 # Installing
 
 Glimmer uses [Ember CLI](https://ember-cli.com/), the battle-tested command-line interface tool (CLI) from the Ember project, to help you create and manage your applications.

--- a/src/partials/_hero.ejs
+++ b/src/partials/_hero.ejs
@@ -3,7 +3,7 @@
     <h2 class="mb0">Fast and light-weight UI components for the web</h2>
 
     <h3 class="mt1">
-      With the attention to detail you've come to expect from <a href="https://emberjs.com/">Ember</a>.
+      Available for use as web components, for standalone apps, or from within <a href="https://emberjs.com/">Ember.js</a>.
     </h3>
   </div>
 </section>

--- a/src/partials/_introduction.ejs
+++ b/src/partials/_introduction.ejs
@@ -17,20 +17,15 @@
           <small>Start the development server</small><br>
           <code>cd my-app/ &amp;&amp; ember s</code>
         </li>
-        <li>
-          See the 
-          <a href="https://glimmerjs.com/api/">
-            Glimmer API docs
-          </a>
-            and
-          <a href="https://glimmerjs.com/guides/">
-            Guides
-          </a>
-          to learn more!
-        </li>
       </ol>
 
-      <h2>Use in Ember.js</h2>
+      <% if (showGuides) { %>
+        <a class="button guides-button" href="/guides/installing">Getting Started Guide</a>
+      <% } else { %>
+        <a class="button" href="/api">Browse API Docs</a>
+      <% } %>
+
+      <h2>Use in Ember.js:</h2>
 
       <ol>
         <li>
@@ -57,12 +52,6 @@
           to learn more!
         </li>
       </ol>
-
-      <% if (showGuides) { %>
-        <a class="button" href="/guides/installing">Getting Started Guide</a>
-      <% } else { %>
-        <a class="button" href="/api">Browse API Docs</a>
-      <% } %>
     </div>
 
     <div class="md-col md-col-6 px2">

--- a/src/partials/_introduction.ejs
+++ b/src/partials/_introduction.ejs
@@ -1,8 +1,7 @@
 <section class="page-section introduction">
   <div class="clearfix mxn2">
     <div class="md-col md-col-6 px2">
-      <h2>Quickstart</h2>
-
+      <h2>Glimmer App Quickstart</h2>
       <ol>
         <li>
           <small>Install the Ember build tool:</small><br>
@@ -18,8 +17,46 @@
           <small>Start the development server</small><br>
           <code>cd my-app/ &amp;&amp; ember s</code>
         </li>
+        <li>
+          See the 
+          <a href="https://glimmerjs.com/api/">
+            Glimmer API docs
+          </a>
+            and
+          <a href="https://glimmerjs.com/guides/">
+            Guides
+          </a>
+          to learn more!
+        </li>
       </ol>
 
+      <h2>Use in Ember.js</h2>
+
+      <ol>
+        <li>
+          <small>Install Glimmer packages in your Ember app:</small><br>
+          <code>npm install --dev @glimmer/component @glimmer/tracking</code>
+        </li>
+
+        <li>
+          <small>Generate a Glimmer Component</small><br>
+          <code>ember generate my-component -gc</code>
+        </li>
+        <li>
+          See the Ember API docs for 
+          <a href="https://api.emberjs.com/ember/release/modules/@glimmer%2Fcomponent">
+            @glimmer/component
+          </a>
+          and
+          <a href="https://api.emberjs.com/ember/release/modules/@glimmer%2F">
+            @glimmer/tracking
+          </a>, and read the
+          <a href="https://guides.emberjs.com">
+            Ember Guides
+          </a>
+          to learn more!
+        </li>
+      </ol>
 
       <% if (showGuides) { %>
         <a class="button" href="/guides/installing">Getting Started Guide</a>

--- a/src/styles/components/_button.scss
+++ b/src/styles/components/_button.scss
@@ -4,3 +4,8 @@
   border-radius: 0.25rem;
   padding: 0.75rem 1rem;
 }
+
+.guides-button {
+  margin: 1em 0 2em calc(2.875rem + 1rem);
+  display: inline-block;
+}


### PR DESCRIPTION
As discussed in some Octane team meetings, we should update the landing page to give lost Ember users some clues about where they should look for docs.

I modified the landing intro, added an "installing in Ember" section, and then in the Guides, added a welcome message.
![Screenshot_2019-11-17 Glimmer(1)](https://user-images.githubusercontent.com/16627268/69017634-511f0600-0976-11ea-869d-76a92fb0d4ea.png)



![Screenshot_2019-11-17 Glimmer(2)](https://user-images.githubusercontent.com/16627268/69017622-377dbe80-0976-11ea-8e51-ea4a6786640a.png)

