### PR TITLE
Replace link to Ember docs until Octane ships

### DIFF
--- a/src/partials/_introduction.ejs
+++ b/src/partials/_introduction.ejs
@@ -38,16 +38,9 @@
           <code>ember generate my-component -gc</code>
         </li>
         <li>
-          See the Ember API docs for 
-          <a href="https://api.emberjs.com/ember/release/modules/@glimmer%2Fcomponent">
-            @glimmer/component
-          </a>
-          and
-          <a href="https://api.emberjs.com/ember/release/modules/@glimmer%2F">
-            @glimmer/tracking
-          </a>, and read the
-          <a href="https://guides.emberjs.com">
-            Ember Guides
+          See the
+          <a href="https://emberjs.com/editions/octane">
+            Ember Octane Guides
           </a>
           to learn more!
         </li>


### PR DESCRIPTION
#121 was deployed a bit prematurely. It contains links to docs that aren't live yet, so this changes the links to use the Octane landing page in the meantime.